### PR TITLE
secp256k1: add DLEQVerify

### DIFF
--- a/api/firmware/secp256k1.go
+++ b/api/firmware/secp256k1.go
@@ -15,6 +15,7 @@
 package firmware
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"math/big"
 
@@ -54,6 +55,63 @@ func antikleptoVerify(hostNonce, signerCommitment, signature []byte) error {
 		return errp.New("Could not verify that the host nonce was contributed to the signature. " +
 			"If this happens repeatedly, the device might be attempting to leak the " +
 			"seed through the signature.")
+	}
+	return nil
+}
+
+// Verifies a DLEQ proof.
+//
+// A DLEQ (discrete log equivalence) proof proves that the discrete log of p1 to the secp256k1 base
+// G is the same as the discrete log of p2 to another base gen2.
+//
+// Same as
+// https://github.com/BlockstreamResearch/secp256k1-zkp/blob/6152622613fdf1c5af6f31f74c427c4e9ee120ce/src/modules/ecdsa_adaptor/dleq_impl.h#L129
+// with default noncefp and ndata==NULL).
+func DLEQVerify(proof []byte, p1, gen2, p2 *btcec.PublicKey) error {
+	if len(proof) != 64 {
+		return errp.New("proof must be 64 bytes")
+	}
+	s := proof[:32]
+	e := proof[32:]
+	curve := btcec.S256()
+
+	// R1 = s*G  - e*P1
+	sPubX, sPubY := curve.ScalarBaseMult(s)
+	eP1X, eP1Y := curve.ScalarMult(p1.X(), p1.Y(), e)
+	// Negate eP1
+	eP1Y = new(big.Int).Sub(curve.P, eP1Y)
+	r1PubX, r1PubY := curve.Add(sPubX, sPubY, eP1X, eP1Y)
+
+	/* R2 = s*gen2 - e*P2 */
+	sGen2X, sGen2Y := curve.ScalarMult(gen2.X(), gen2.Y(), s)
+	eP2X, eP2Y := curve.ScalarMult(p2.X(), p2.Y(), e)
+	// Negate eP2
+	eP2Y = new(big.Int).Sub(curve.P, eP2Y)
+	r2PubX, r2PubY := curve.Add(sGen2X, sGen2Y, eP2X, eP2Y)
+
+	toPub := func(x, y *big.Int) *btcec.PublicKey {
+		var xx, yy btcec.FieldVal
+		xx.SetByteSlice(x.Bytes())
+		yy.SetByteSlice(y.Bytes())
+		return btcec.NewPublicKey(&xx, &yy)
+	}
+	challenge := func() *big.Int {
+		var b bytes.Buffer
+		b.Write(p1.SerializeCompressed())
+		b.Write(gen2.SerializeCompressed())
+		b.Write(p2.SerializeCompressed())
+		b.Write(toPub(r1PubX, r1PubY).SerializeCompressed())
+		b.Write(toPub(r2PubX, r2PubY).SerializeCompressed())
+		hash := taggedSha256([]byte("DLEQ"), b.Bytes())
+		return new(big.Int).SetBytes(hash)
+	}
+	modEqual := func(x, y, n *big.Int) bool {
+		return new(big.Int).Mod(x, n).Cmp(new(big.Int).Mod(y, n)) == 0
+	}
+	eExpected := challenge()
+	eInt := new(big.Int).SetBytes(e)
+	if !modEqual(eExpected, eInt, curve.N) {
+		return errp.New("DLEQ proof verification failed")
 	}
 	return nil
 }

--- a/api/firmware/secp256k1_test.go
+++ b/api/firmware/secp256k1_test.go
@@ -3,6 +3,7 @@ package firmware
 import (
 	"testing"
 
+	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,4 +48,23 @@ func TestAntikleptoVerify(t *testing.T) {
 		test.hostNonce[0]++
 		require.Error(t, antikleptoVerify(test.hostNonce, test.signerCommitment, test.signature))
 	}
+}
+
+func TestDLEQVerify(t *testing.T) {
+	// secret key sk=077eb75a52eca24cdedf058c92f1ca8b9d4841771fd6baa3d27885fb5b49fba2
+	// is the secret key in pubKey=sk*G and otherPubKey=sk*otherBase.
+	//
+	// Test fixture created by running dleq_verify() in
+	// https://github.com/BlockstreamResearch/secp256k1-zkp/blob/6152622613fdf1c5af6f31f74c427c4e9ee120ce/src/modules/ecdsa_adaptor/dleq_impl.h
+	// with the above secret key, p1 being sk*G,
+	// 0389140f7bb852f020f154e55908fe3699dc9f65153e681527f0d55aabed937f4b for gen2, and p2=sk*gen2.
+
+	proof := unhex("6c885f825f6ce7565bc6d0bfda90506b11e2682dfe943f5a85badf1c8a96edc5f5e03f5ee2c58bf979646fbada920f9f1c5bd92805fb5b01534b42d26a550f79")
+	pubKey, err := btcec.ParsePubKey(unhex("021b8594084a12da837a78f9337e3d29169025a8ddbe9f9933a131607c6e62d21e"))
+	require.NoError(t, err)
+	otherBase, err := btcec.ParsePubKey(unhex("0389140f7bb852f020f154e55908fe3699dc9f65153e681527f0d55aabed937f4b"))
+	require.NoError(t, err)
+	otherPubKey, err := btcec.ParsePubKey(unhex("03019807775b92c83d24e3001b55f60373e0bdc7d7cc7bc86befecf5bb987b54ac"))
+	require.NoError(t, err)
+	require.NoError(t, DLEQVerify(proof, pubKey, otherBase, otherPubKey))
 }


### PR DESCRIPTION
A quick port of

https://github.com/BlockstreamResearch/secp256k1-zkp/blob/6152622613fdf1c5af6f31f74c427c4e9ee120ce/src/modules/ecdsa_adaptor/dleq_impl.h#L129

A DLEQ (discrete log equivalence) proof proves that the discrete log of P1 to the secp256k1 base G is the same as the discrete log of P2 to another base.

This is useful to verify that a silent payment (BIP-352) output created by a signer was created correctly.