### PR TITLE
api/firmware: remove "remove sdcard" functionality

### DIFF
--- a/api/firmware/sdcard.go
+++ b/api/firmware/sdcard.go
@@ -37,12 +37,12 @@ func (device *Device) CheckSDCard() (bool, error) {
 	return sdCardInserted.CheckSdcard.Inserted, nil
 }
 
-// InsertRemoveSDCard sends a command to the device to insert of remove the sd card based on the workflow state.
-func (device *Device) InsertRemoveSDCard(action messages.InsertRemoveSDCardRequest_SDCardAction) error {
+// InsertSDCard sends a command to the device to prompt to insert the sd card.
+func (device *Device) InsertSDCard() error {
 	request := &messages.Request{
 		Request: &messages.Request_InsertRemoveSdcard{
 			InsertRemoveSdcard: &messages.InsertRemoveSDCardRequest{
-				Action: action,
+				Action: messages.InsertRemoveSDCardRequest_INSERT_CARD,
 			},
 		},
 	}

--- a/api/firmware/sdcard_test.go
+++ b/api/firmware/sdcard_test.go
@@ -17,7 +17,6 @@ package firmware
 import (
 	"testing"
 
-	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages"
 	"github.com/stretchr/testify/require"
 )
 
@@ -31,12 +30,9 @@ func TestSimulatorCheckSDCard(t *testing.T) {
 	})
 }
 
-func TestSimutorInsertRemoveSDCard(t *testing.T) {
+func TestSimutorInsertSDCard(t *testing.T) {
 	testSimulatorsAfterPairing(t, func(t *testing.T, device *Device) {
 		t.Helper()
-		require.NoError(t,
-			device.InsertRemoveSDCard(messages.InsertRemoveSDCardRequest_INSERT_CARD))
-		require.NoError(t,
-			device.InsertRemoveSDCard(messages.InsertRemoveSDCardRequest_REMOVE_CARD))
+		require.NoError(t, device.InsertSDCard())
 	})
 }


### PR DESCRIPTION
It will be removed from the firmware as we never ended up using it.