### PR TITLE
firmware/btc: return nice error message if silent payments not supported

### DIFF
--- a/api/firmware/btc.go
+++ b/api/firmware/btc.go
@@ -306,6 +306,10 @@ func (device *Device) BTCSign(
 		}
 	}
 
+	if containsSilentPaymentOutputs && !device.version.AtLeast(semver.NewSemVer(9, 21, 0)) {
+		return nil, nil, UnsupportedError("9.21.0")
+	}
+
 	signatures := make([][]byte, len(tx.Inputs))
 	next, err := device.queryBtcSign(&messages.Request{
 		Request: &messages.Request_BtcSignInit{

--- a/api/firmware/btc_test.go
+++ b/api/firmware/btc_test.go
@@ -667,7 +667,7 @@ func TestSimulatorBTCSignSilentPayment(t *testing.T) {
 				generatedOutputs,
 			)
 		} else {
-			require.Error(t, err)
+			require.EqualError(t, err, UnsupportedError("9.21.0").Error())
 		}
 	})
 }


### PR DESCRIPTION
Otherwise an outdated firmware would just return "generic error" when running into such an output.