### PR TITLE
deps: replace karabale/usb with karalabe/hid

### DIFF
--- a/cmd/miniscript/main.go
+++ b/cmd/miniscript/main.go
@@ -38,7 +38,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg/chainhash"
 	"github.com/btcsuite/btcd/txscript"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/karalabe/usb"
+	"github.com/karalabe/hid"
 )
 
 const (
@@ -55,7 +55,7 @@ func errpanic(err error) {
 	}
 }
 
-func isBitBox02(deviceInfo *usb.DeviceInfo) bool {
+func isBitBox02(deviceInfo *hid.DeviceInfo) bool {
 	return (deviceInfo.Product == common.FirmwareHIDProductStringStandard ||
 		deviceInfo.Product == common.FirmwareHIDProductStringBTCOnly) &&
 		deviceInfo.VendorID == bitbox02VendorID &&
@@ -176,8 +176,8 @@ func (m multipath) derivationSuffix(isChange bool, addressIndex uint32) []uint32
 }
 
 func main() {
-	deviceInfo := func() *usb.DeviceInfo {
-		infos, err := usb.EnumerateHid(0, 0)
+	deviceInfo := func() *hid.DeviceInfo {
+		infos, err := hid.Enumerate(0, 0)
 		errpanic(err)
 		for idx := range infos {
 			di := &infos[idx]

--- a/cmd/paymentrequest/main.go
+++ b/cmd/paymentrequest/main.go
@@ -32,7 +32,7 @@ import (
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/wire"
-	"github.com/karalabe/usb"
+	"github.com/karalabe/hid"
 )
 
 const (
@@ -57,7 +57,7 @@ func errpanic(err error) {
 	}
 }
 
-func isBitBox02(deviceInfo *usb.DeviceInfo) bool {
+func isBitBox02(deviceInfo *hid.DeviceInfo) bool {
 	return (deviceInfo.Product == common.FirmwareHIDProductStringStandard ||
 		deviceInfo.Product == common.FirmwareHIDProductStringBTCOnly) &&
 		deviceInfo.VendorID == bitbox02VendorID &&
@@ -107,8 +107,8 @@ func computeSighash(paymentRequest *messages.BTCPaymentRequestRequest, slip44 ui
 }
 
 func main() {
-	deviceInfo := func() *usb.DeviceInfo {
-		infos, err := usb.EnumerateHid(0, 0)
+	deviceInfo := func() *hid.DeviceInfo {
+		infos, err := hid.Enumerate(0, 0)
 		errpanic(err)
 		for idx := range infos {
 			di := &infos[idx]

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -29,7 +29,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages"
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/mocks"
 	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid"
-	"github.com/karalabe/usb"
+	"github.com/karalabe/hid"
 )
 
 const (
@@ -45,7 +45,7 @@ func errpanic(err error) {
 	}
 }
 
-func isBitBox02(deviceInfo *usb.DeviceInfo) bool {
+func isBitBox02(deviceInfo *hid.DeviceInfo) bool {
 	return (deviceInfo.Product == common.FirmwareHIDProductStringStandard ||
 		deviceInfo.Product == common.FirmwareHIDProductStringBTCOnly) &&
 		deviceInfo.VendorID == bitbox02VendorID &&
@@ -172,8 +172,8 @@ func signFromTxID(device *firmware.Device, txID string) {
 }
 
 func main() {
-	deviceInfo := func() *usb.DeviceInfo {
-		infos, err := usb.EnumerateHid(0, 0)
+	deviceInfo := func() *hid.DeviceInfo {
+		infos, err := hid.Enumerate(0, 0)
 		errpanic(err)
 		for idx := range infos {
 			di := &infos[idx]

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.1.0
 	github.com/flynn/noise v1.1.0
-	github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9
+	github.com/karalabe/hid v1.0.1-0.20240306101548-573246063e52
 	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/crypto v0.27.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/jessevdk/go-flags v0.0.0-20141203071132-1679536dcc89/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jrick/logrotate v1.0.0/go.mod h1:LNinyqDIJnpAur+b8yyulnQw/wDuN1+BYKlTRt3OuAQ=
-github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9 h1:ZHuwnjpP8LsVsUYqTqeVAI+GfDfJ6UNPrExZF+vX/DQ=
-github.com/karalabe/usb v0.0.0-20191104083709-911d15fe12a9/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
+github.com/karalabe/hid v1.0.1-0.20240306101548-573246063e52 h1:msKODTL1m0wigztaqILOtla9HeW1ciscYG4xjLtvk5I=
+github.com/karalabe/hid v1.0.1-0.20240306101548-573246063e52/go.mod h1:qk1sX/IBgppQNcGCRoj90u6EGC056EBoIc1oEjCWla8=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=


### PR DESCRIPTION
More up to date, same dep as in the BitBoxApp. The old one does not work on newer macOS versions.

This is only in the demo/helper cmd scripts, not part of the main library.