### PR TITLE
api/firmware: prevent sleep on macOS during long running queries

### DIFF
--- a/util/sleep/sleep.go
+++ b/util/sleep/sleep.go
@@ -1,0 +1,25 @@
+// Copyright 2024 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !darwin || nosleep
+
+package sleep
+
+// Prevent is a no-op on non macOS platforms or when nosleep is configured.
+func Prevent() {
+}
+
+// Allow is a no-op on non macOS platforms or when nosleep is configured.
+func Allow() {
+}

--- a/util/sleep/sleep_darwin.go
+++ b/util/sleep/sleep_darwin.go
@@ -1,0 +1,55 @@
+// Copyright 2024 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build darwin && !nosleep
+
+package sleep
+
+/*
+#cgo LDFLAGS: -framework IOKit
+#include <IOKit/pwr_mgt/IOPMLib.h>
+#include <IOKit/IOReturn.h>
+#include <stdbool.h>
+
+static IOPMAssertionID _assertionID;
+static bool _assertionCreated = false;
+void preventSleep() {
+    if (_assertionCreated) {
+        return;
+    }
+    IOReturn success = IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep, kIOPMAssertionLevelOn, CFSTR("Prevent Sleep"), &_assertionID);
+    if (success == kIOReturnSuccess) {
+        // Successfully disabled sleep.
+        _assertionCreated = true;
+    }
+}
+
+void allowSleep() {
+   if (_assertionCreated) {
+       IOPMAssertionRelease(_assertionID);
+       _assertionCreated = false;
+   }
+}
+*/
+import "C"
+
+// Prevent prevents macOS from going to sleep. Must be paired with `Allow()`.
+func Prevent() {
+	C.preventSleep()
+}
+
+// Allow allows macOS from going to sleep.
+func Allow() {
+	C.allowSleep()
+}


### PR DESCRIPTION
When doing long interactions on the device, e.g. recovering from 24 words, and macOS goes to sleep, USB interaction would be slowed down and the workflow would be aborted.

This commit prevents this from happening by preventing macOS from going to sleep during such an interaction.

The alternative was to expose callbacks here and let the BitBoxApp (and other users) implement the callbacks, but it seems like every app that uses this lib would want this. In case not, we add a build flag if not desired.