### PR TITLE
util/sleep: exclude iOS

### DIFF
--- a/util/sleep/sleep.go
+++ b/util/sleep/sleep.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build !darwin || nosleep
+//go:build !darwin || ios || nosleep
 
 package sleep
 

--- a/util/sleep/sleep_macos.go
+++ b/util/sleep/sleep_macos.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-//go:build darwin && !nosleep
+//go:build darwin && !ios && !nosleep
 
 package sleep
 


### PR DESCRIPTION
The previous filters would also compile the sleep_darwin.go file for iOS, failing compilation, as the `darwin` build tag also matches on iOS:

https://pkg.go.dev/cmd/go

```
Using GOOS=ios matches build tags and files as for GOOS=darwin in
addition to ios tags and files.
```

We need to exclude iOS explicitly here.