### PR TITLE
update min Go version to 1.22 and update golangci, fix lints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@
 name: ci
 on: [push, pull_request]
 env:
-  GO_VERSION: "^1.20"
-  GOLANGCI_LINT_VERSION: "v1.55.2"
+  GO_VERSION: "^1.22"
+  GOLANGCI_LINT_VERSION: "v1.62.0"
 
 jobs:
   lint:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,9 +17,6 @@ run:
 
 # output configuration options
 output:
-  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
-  format: colored-line-number
-
   # print lines of code with issue, default is true
   print-issued-lines: true
 
@@ -31,28 +28,11 @@ output:
 linters-settings:
   gocritic:
     enabled-checks:
-      - assignOp
       - builtinShadow
-      - captLocal
-      - caseOrder
-      - defaultCaseOrder
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - elseif
-      - flagDeref
-      - ifElseChain
       - nilValReturn
       - rangeExprCopy
       - rangeValCopy
-      - regexpMust
-      - sloppyLen
-      - switchTrue
-      - typeSwitchVar
       - typeUnparen
-      - underef
-      - unlambda
-      - unslice
   gocyclo:
     min-complexity: 29
   maligned:
@@ -81,9 +61,6 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - golint
-    - scopelint
-    - interfacer
     - gosec
     - bodyclose
     - dogsled
@@ -93,17 +70,14 @@ linters:
     - gochecknoinits
     - gocognit
     - godox
-    - goerr113 # can't switch to errors.Is due to GopherJS still on go1.12
-    - gomnd
     - lll
-    - maligned
     - nestif
     - prealloc
     - stylecheck
     - whitespace
     - wsl
-    - execinquery
     - ireturn
+    - err113
     - wrapcheck
     - varnamelen
     - tagliatelle
@@ -112,12 +86,10 @@ linters:
     - noctx
     - nlreturn
     - cyclop
-    - ifshort
     - exhaustive
     - nilnil
     - nilerr
     - forcetypeassert
-    - exhaustivestruct
     - exhaustruct
     - maintidx
     - errorlint
@@ -128,19 +100,16 @@ linters:
     - makezero
     - nolintlint
     - gocyclo
-    - nosnakecase
     - interfacebloat
     - revive
     - musttag
-    - structcheck
-    - deadcode
-    - varcheck
     - depguard
     - protogetter
     - gosmopolitan
     - inamedparam
     # could not find a way to disable float-compare: https://github.com/golangci/golangci-lint/issues/4187
     - testifylint
+    - mnd
   disable-all: false
 
 issues:

--- a/api/bootloader/device_test.go
+++ b/api/bootloader/device_test.go
@@ -126,7 +126,6 @@ func TestVersions(t *testing.T) {
 			"x\x00aaaaaaaa", // wrong cmd, good len
 			"v\x01aaaaaaaa", // wrong op status
 		} {
-			testResponse := testResponse
 			env.communication.query = func([]byte) ([]byte, error) {
 				return []byte(testResponse), nil
 			}
@@ -149,7 +148,6 @@ func TestGetHashes(t *testing.T) {
 			{true, false, "h\x01\x00"},
 			{true, true, "h\x01\x01"},
 		} {
-			test := test
 			t.Run("happy", func(t *testing.T) {
 				h1 := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 				h2 := "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -279,7 +277,7 @@ func TestUpgradeFirmware(t *testing.T) {
 		require.Equal(t, []byte("ed"), msg)
 
 		// flash chunks
-		for chunkIndex := 0; chunkIndex < numChunks; chunkIndex++ {
+		for chunkIndex := range numChunks {
 			msg, status = takeOne()
 
 			require.True(t, status.Upgrading)

--- a/api/firmware/device_test.go
+++ b/api/firmware/device_test.go
@@ -52,7 +52,7 @@ func runSimulator(filename string) (func() error, *Device, error) {
 	}
 	var conn net.Conn
 	var err error
-	for i := 0; i < 200; i++ {
+	for range 200 {
 		conn, err = net.Dial("tcp", "localhost:15423")
 		if err == nil {
 			break

--- a/api/firmware/query.go
+++ b/api/firmware/query.go
@@ -90,7 +90,7 @@ func (device *Device) rawQueryV7(msg []byte) ([]byte, error) {
 				device.log.Debug("unexpected NACK response in first loop iteration")
 			} else {
 				logStr := "unexpected NACK response; last successful retry query intervals (newest first) were: "
-				for i := 0; i < lastQueryTimes.Len()-1; i++ {
+				for range lastQueryTimes.Len() - 1 {
 					if lastQueryTimes.Value == nil || lastQueryTimes.Prev().Value == nil {
 						break
 					}

--- a/communication/usart/usart_test.go
+++ b/communication/usart/usart_test.go
@@ -95,7 +95,6 @@ func TestReadWrite(t *testing.T) {
 
 func TestWrite(t *testing.T) {
 	for _, test := range tests {
-		test := test
 		t.Run("", func(t *testing.T) {
 			buf := new(bytes.Buffer)
 			err := usart.NewCommunication(
@@ -110,7 +109,6 @@ func TestWrite(t *testing.T) {
 
 func TestRead(t *testing.T) {
 	for _, test := range tests {
-		test := test
 		t.Run("", func(t *testing.T) {
 			communication := usart.NewCommunication(
 				&deviceMock{

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/BitBoxSwiss/bitbox02-api-go
 
-go 1.21
+go 1.22
 
 require (
 	github.com/benma/miniscript-go v0.0.0-20240226152043-f7c34099edf9

--- a/util/semver/semver.go
+++ b/util/semver/semver.go
@@ -81,7 +81,7 @@ func (version *SemVer) String() string {
 }
 
 // MarshalJSON implements json.Marshaler.
-func (version SemVer) MarshalJSON() ([]byte, error) {
+func (version *SemVer) MarshalJSON() ([]byte, error) {
 	return json.Marshal(version.String())
 }
 


### PR DESCRIPTION
golangci.yml was cleaned up basd on warnings it printed.

Go 1.22 because it fixes the loop reference reuse.