### PR TITLE
common: add product strings for BitBox02Plus

### DIFF
--- a/api/bootloader/device.go
+++ b/api/bootloader/device.go
@@ -44,8 +44,10 @@ const (
 )
 
 var sigDataMagic = map[common.Product]uint32{
-	common.ProductBitBox02Multi:   0x653f362b,
-	common.ProductBitBox02BTCOnly: 0x11233B0B,
+	common.ProductBitBox02Multi:       0x653f362b,
+	common.ProductBitBox02BTCOnly:     0x11233B0B,
+	common.ProductBitBox02PlusMulti:   0x5b648ceb,
+	common.ProductBitBox02PlusBTCOnly: 0x48714774,
 }
 
 // Communication contains functions needed to communicate with the device.

--- a/api/bootloader/device_test.go
+++ b/api/bootloader/device_test.go
@@ -58,6 +58,8 @@ func testConfigurations(t *testing.T, run func(*testing.T, *testEnv)) {
 	for _, product := range []common.Product{
 		common.ProductBitBox02Multi,
 		common.ProductBitBox02BTCOnly,
+		common.ProductBitBox02PlusMulti,
+		common.ProductBitBox02PlusBTCOnly,
 	} {
 		var env testEnv
 		env.product = product

--- a/api/common/common.go
+++ b/api/common/common.go
@@ -1,4 +1,5 @@
 // Copyright 2018-2019 Shift Cryptosecurity AG
+// Copyright 2025 Shift Crypto AG
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,28 +28,57 @@ const (
 	// ProductBitBox02BTCOnly is the btc-only edition of the BitBox02, restricting functionality to
 	// Bitcoin.
 	ProductBitBox02BTCOnly Product = "bitbox02-btconly"
+
+	// ProductBitBox02PlusMulti is the multi edition of the BitBox02 Plus.
+	ProductBitBox02PlusMulti Product = "bitbox02-plus-multi"
+	// ProductBitBox02PlusBTCOnly is the btc-only edition of the BitBox02 Plus, restricting
+	// functionality to Bitcoin.
+	ProductBitBox02PlusBTCOnly Product = "bitbox02-plus-btconly"
 )
 
 const (
-	// FirmwareHIDProductStringStandard is the hid product string of the standard edition firmware.
-	FirmwareHIDProductStringStandard = "BitBox02"
-	// FirmwareHIDProductStringBTCOnly is the hid product string of the btc-only edition firmware.
-	FirmwareHIDProductStringBTCOnly = "BitBox02BTC"
+	// FirmwareDeviceProductStringBitBox02Multi is the product string of the BitBox02 multi edition
+	// firmware. It appears in the HID descriptor.
+	FirmwareDeviceProductStringBitBox02Multi = "BitBox02"
+	// FirmwareDeviceProductStringBitBox02BTCOnly is the product string of the BitBox02 btc-only
+	// edition firmware. It appears in the HID descriptor.
+	FirmwareDeviceProductStringBitBox02BTCOnly = "BitBox02BTC"
 
-	// BootloaderHIDProductStringStandard is the hid product string of the standard edition bootloader.
-	BootloaderHIDProductStringStandard = "bb02-bootloader"
-	// BootloaderHIDProductStringBTCOnly is the hid product string of the btc-only edition bootloader.
-	BootloaderHIDProductStringBTCOnly = "bb02btc-bootloader"
+	// BootloaderDeviceProductStringBitBox02Multi is the product string of the BitBox02 multi
+	// edition bootloader. It appears in the HID descriptor.
+	BootloaderDeviceProductStringBitBox02Multi = "bb02-bootloader"
+	// BootloaderDeviceProductStringBitBox02BTCOnly is the product string of the BitBox02 btc-only
+	// edition bootloader. It appears in the HID descriptor.
+	BootloaderDeviceProductStringBitBox02BTCOnly = "bb02btc-bootloader"
+
+	// FirmwareDeviceProductStringBitBox02PlusMulti the product string of the "BitBox02 Plus" multi
+	// edition firmware. It appears in the HID descriptor and the Bluetooth characteristic.
+	FirmwareDeviceProductStringBitBox02PlusMulti = "bb02p-multi"
+	// FirmwareDeviceProductStringBitBox02PlusBTCOnly is the product string of the "BitBox02 Plus"
+	// btc-only edition firmware. It appears in the HID descriptor and the Bluetooth characteristic.
+	FirmwareDeviceProductStringBitBox02PlusBTCOnly = "bb02p-btconly"
+
+	// BootloaderDeviceProductStringBitBox02Multi is the product string of the "BitBox02 Plus" multi
+	// edition bootloader. It appears in the HID descriptor and the Bluetooth characteristic.
+	BootloaderDeviceProductStringBitBox02PlusMulti = "bb02p-bl-multi"
+	// BootloaderDeviceProductStringBitBox02BTCOnly is the product string of the "BitBox02 Plus"
+	// btc-only edition bootloader. It appears in the HID descriptor and the Bluetooth
+	// characteristic.
+	BootloaderDeviceProductStringBitBox02PlusBTCOnly = "bb02p-bl-btconly"
 )
 
-// ProductFromHIDProductString returns the firmware or bootloader product based on the usb HID
+// ProductFromDeviceProductString returns the firmware or bootloader product based on the usb Device
 // product string. Returns an error for an invalid/unrecognized product string.
-func ProductFromHIDProductString(productString string) (Product, error) {
+func ProductFromDeviceProductString(productString string) (Product, error) {
 	switch productString {
-	case FirmwareHIDProductStringStandard, BootloaderHIDProductStringStandard:
+	case FirmwareDeviceProductStringBitBox02Multi, BootloaderDeviceProductStringBitBox02Multi:
 		return ProductBitBox02Multi, nil
-	case FirmwareHIDProductStringBTCOnly, BootloaderHIDProductStringBTCOnly:
+	case FirmwareDeviceProductStringBitBox02BTCOnly, BootloaderDeviceProductStringBitBox02BTCOnly:
 		return ProductBitBox02BTCOnly, nil
+	case FirmwareDeviceProductStringBitBox02PlusMulti, BootloaderDeviceProductStringBitBox02PlusMulti:
+		return ProductBitBox02PlusMulti, nil
+	case FirmwareDeviceProductStringBitBox02PlusBTCOnly, BootloaderDeviceProductStringBitBox02PlusBTCOnly:
+		return ProductBitBox02PlusBTCOnly, nil
 	default:
 		return "", errp.New("unrecognized product")
 	}

--- a/api/firmware/device_test.go
+++ b/api/firmware/device_test.go
@@ -371,8 +371,10 @@ func newDevice(
 
 	{ // Test upgrade required and actual upgrade, which for the firmware only means to reboot into the bootloader.
 		lowestSupported := map[common.Product]*semver.SemVer{
-			common.ProductBitBox02Multi:   lowestSupportedFirmwareVersion,
-			common.ProductBitBox02BTCOnly: lowestSupportedFirmwareVersionBTCOnly,
+			common.ProductBitBox02Multi:       lowestSupportedFirmwareVersion,
+			common.ProductBitBox02BTCOnly:     lowestSupportedFirmwareVersionBTCOnly,
+			common.ProductBitBox02PlusMulti:   lowestSupportedFirmwareVersion,
+			common.ProductBitBox02PlusBTCOnly: lowestSupportedFirmwareVersionBTCOnly,
 		}
 		lowestSupportedFirmwareVersion, ok := lowestSupported[product]
 		require.True(t, ok)
@@ -453,6 +455,8 @@ func testConfigurations(t *testing.T, run func(*testing.T, *testEnv)) {
 	products := []common.Product{
 		common.ProductBitBox02Multi,
 		common.ProductBitBox02BTCOnly,
+		common.ProductBitBox02PlusMulti,
+		common.ProductBitBox02PlusBTCOnly,
 	}
 	for _, version := range versions {
 		for _, product := range products {

--- a/api/firmware/pairing.go
+++ b/api/firmware/pairing.go
@@ -157,9 +157,9 @@ func (device *Device) ChannelHashVerify(ok bool) {
 		_ = device.config.AddDeviceStaticPubkey(device.deviceNoiseStaticPubkey)
 		requireUpgrade := false
 		switch *device.product {
-		case common.ProductBitBox02Multi:
+		case common.ProductBitBox02Multi, common.ProductBitBox02PlusMulti:
 			requireUpgrade = !device.version.AtLeast(lowestSupportedFirmwareVersion)
-		case common.ProductBitBox02BTCOnly:
+		case common.ProductBitBox02BTCOnly, common.ProductBitBox02PlusBTCOnly:
 			requireUpgrade = !device.version.AtLeast(lowestSupportedFirmwareVersionBTCOnly)
 		default:
 			device.log.Error(fmt.Sprintf("unrecognized product: %s", *device.product), nil)

--- a/cmd/bootloader/main.go
+++ b/cmd/bootloader/main.go
@@ -42,8 +42,10 @@ func errpanic(err error) {
 }
 
 func isBitBox02Bootloader(deviceInfo *hid.DeviceInfo) bool {
-	return (deviceInfo.Product == common.BootloaderHIDProductStringStandard ||
-		deviceInfo.Product == common.BootloaderHIDProductStringBTCOnly) &&
+	return (deviceInfo.Product == common.BootloaderDeviceProductStringBitBox02Multi ||
+		deviceInfo.Product == common.BootloaderDeviceProductStringBitBox02BTCOnly ||
+		deviceInfo.Product == common.BootloaderDeviceProductStringBitBox02PlusMulti ||
+		deviceInfo.Product == common.BootloaderDeviceProductStringBitBox02PlusBTCOnly) &&
 		deviceInfo.VendorID == bitbox02VendorID &&
 		deviceInfo.ProductID == bitbox02ProductID &&
 		(deviceInfo.UsagePage == 0xffff || deviceInfo.Interface == 0)
@@ -84,7 +86,7 @@ func main() {
 	comm := u2fhid.NewCommunication(hidDevice, bitbox02BootloaderCMD)
 	version, err := parseVersion(deviceInfo.Serial)
 	errpanic(err)
-	product, err := common.ProductFromHIDProductString(deviceInfo.Product)
+	product, err := common.ProductFromDeviceProductString(deviceInfo.Product)
 	errpanic(err)
 	device := bootloader.NewDevice(version, product, comm, func(*bootloader.Status) {})
 	firmwareVersion, signingPubkeysVersion, err := device.Versions()

--- a/cmd/miniscript/main.go
+++ b/cmd/miniscript/main.go
@@ -56,8 +56,10 @@ func errpanic(err error) {
 }
 
 func isBitBox02(deviceInfo *hid.DeviceInfo) bool {
-	return (deviceInfo.Product == common.FirmwareHIDProductStringStandard ||
-		deviceInfo.Product == common.FirmwareHIDProductStringBTCOnly) &&
+	return (deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02Multi ||
+		deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02BTCOnly ||
+		deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02PlusMulti ||
+		deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02PlusBTCOnly) &&
 		deviceInfo.VendorID == bitbox02VendorID &&
 		deviceInfo.ProductID == bitbox02ProductID &&
 		(deviceInfo.UsagePage == 0xffff || deviceInfo.Interface == 0)

--- a/cmd/paymentrequest/main.go
+++ b/cmd/paymentrequest/main.go
@@ -58,8 +58,10 @@ func errpanic(err error) {
 }
 
 func isBitBox02(deviceInfo *hid.DeviceInfo) bool {
-	return (deviceInfo.Product == common.FirmwareHIDProductStringStandard ||
-		deviceInfo.Product == common.FirmwareHIDProductStringBTCOnly) &&
+	return (deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02Multi ||
+		deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02BTCOnly ||
+		deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02PlusMulti ||
+		deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02PlusBTCOnly) &&
 		deviceInfo.VendorID == bitbox02VendorID &&
 		deviceInfo.ProductID == bitbox02ProductID &&
 		(deviceInfo.UsagePage == 0xffff || deviceInfo.Interface == 0)

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -46,8 +46,10 @@ func errpanic(err error) {
 }
 
 func isBitBox02(deviceInfo *hid.DeviceInfo) bool {
-	return (deviceInfo.Product == common.FirmwareHIDProductStringStandard ||
-		deviceInfo.Product == common.FirmwareHIDProductStringBTCOnly) &&
+	return (deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02Multi ||
+		deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02BTCOnly ||
+		deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02PlusMulti ||
+		deviceInfo.Product == common.FirmwareDeviceProductStringBitBox02PlusBTCOnly) &&
 		deviceInfo.VendorID == bitbox02VendorID &&
 		deviceInfo.ProductID == bitbox02ProductID &&
 		(deviceInfo.UsagePage == 0xffff || deviceInfo.Interface == 0)


### PR DESCRIPTION
Allows the BitBoxApp to detect the product. These might be placeholder values to be renamed later.

The existing product names are prefixed with BitBox02 for disambiguation.

Standard is renamed to Multi, as that's what the product is actually named.

HID is renamed to Device, as the string is not only used in HID descriptors, but also in the Bluetooth characteristic.