### PR TITLE
firmware/btc: return struct in BTCSign and BTCSignMessage

### DIFF
--- a/cmd/miniscript/main.go
+++ b/cmd/miniscript/main.go
@@ -331,7 +331,7 @@ func main() {
 		}
 		accountKeypath := keyOriginInfo.Keypath
 		mp := multipaths[i]
-		signatures, _, err := device.BTCSign(
+		result, err := device.BTCSign(
 			coin,
 			[]*messages.BTCScriptConfigWithKeypath{
 				{
@@ -390,8 +390,8 @@ func main() {
 		errpanic(err)
 
 		// Convert to DER encoding
-		signaturesDER := make([][]byte, len(signatures))
-		for sigIndex, signature := range signatures {
+		signaturesDER := make([][]byte, len(result.Signatures))
+		for sigIndex, signature := range result.Signatures {
 			r := new(btcec.ModNScalar)
 			r.SetByteSlice(signature[:32])
 			s := new(btcec.ModNScalar)

--- a/cmd/paymentrequest/main.go
+++ b/cmd/paymentrequest/main.go
@@ -167,7 +167,7 @@ func main() {
 	errpanic(err)
 	paymentRequest.Signature = signature[1:]
 
-	_, _, err = device.BTCSign(
+	_, err = device.BTCSign(
 		messages.BTCCoin_TBTC,
 		[]*messages.BTCScriptConfigWithKeypath{
 			{

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -153,7 +153,7 @@ func signFromTxID(device *firmware.Device, txID string) {
 			Value:   outp.Value,
 		})
 	}
-	_, _, err := device.BTCSign(
+	_, err := device.BTCSign(
 		messages.BTCCoin_TBTC,
 		[]*messages.BTCScriptConfigWithKeypath{
 			{


### PR DESCRIPTION
Better clarity and composes better with generic functions returning a single value.