### PR TITLE
u2fhid: add hid.Device wrapper to fix IOKit timeouts on macOS

### DIFF
--- a/cmd/bluetooth_upgrade/main.go
+++ b/cmd/bluetooth_upgrade/main.go
@@ -80,7 +80,7 @@ func main() {
 	hidDevice, err := deviceInfo.Open()
 	errpanic(err)
 
-	comm := u2fhid.NewCommunication(hidDevice, bitboxCMD)
+	comm := u2fhid.NewCommunication(u2fhid.NewHidDevice(hidDevice), bitboxCMD)
 	device := firmware.NewDevice(nil, nil, &mocks.Config{}, comm, &mocks.Logger{})
 	errpanic(device.Init())
 	device.ChannelHashVerify(true)

--- a/cmd/bootloader/main.go
+++ b/cmd/bootloader/main.go
@@ -83,7 +83,7 @@ func main() {
 	hidDevice, err := deviceInfo.Open()
 	errpanic(err)
 	const bitbox02BootloaderCMD = 0x80 + 0x40 + 0x03
-	comm := u2fhid.NewCommunication(hidDevice, bitbox02BootloaderCMD)
+	comm := u2fhid.NewCommunication(u2fhid.NewHidDevice(hidDevice), bitbox02BootloaderCMD)
 	version, err := parseVersion(deviceInfo.Serial)
 	errpanic(err)
 	product, err := common.ProductFromDeviceProductString(deviceInfo.Product)

--- a/cmd/miniscript/main.go
+++ b/cmd/miniscript/main.go
@@ -203,7 +203,7 @@ func main() {
 	hidDevice, err := deviceInfo.Open()
 	errpanic(err)
 
-	comm := u2fhid.NewCommunication(hidDevice, bitboxCMD)
+	comm := u2fhid.NewCommunication(u2fhid.NewHidDevice(hidDevice), bitboxCMD)
 	device := firmware.NewDevice(nil, nil, &mocks.Config{}, comm, &mocks.Logger{})
 	errpanic(device.Init())
 	device.ChannelHashVerify(true)

--- a/cmd/paymentrequest/main.go
+++ b/cmd/paymentrequest/main.go
@@ -128,7 +128,7 @@ func main() {
 	hidDevice, err := deviceInfo.Open()
 	errpanic(err)
 
-	comm := u2fhid.NewCommunication(hidDevice, bitboxCMD)
+	comm := u2fhid.NewCommunication(u2fhid.NewHidDevice(hidDevice), bitboxCMD)
 	device := firmware.NewDevice(nil, nil, &mocks.Config{}, comm, &mocks.Logger{})
 	errpanic(device.Init())
 	device.ChannelHashVerify(true)

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -194,7 +194,7 @@ func main() {
 	hidDevice, err := deviceInfo.Open()
 	errpanic(err)
 	const bitboxCMD = 0x80 + 0x40 + 0x01
-	comm := u2fhid.NewCommunication(hidDevice, bitboxCMD)
+	comm := u2fhid.NewCommunication(u2fhid.NewHidDevice(hidDevice), bitboxCMD)
 	device := firmware.NewDevice(nil, nil, &mocks.Config{}, comm, &mocks.Logger{})
 	device.SetOnEvent(func(ev firmware.Event, meta interface{}) {
 		if ev == firmware.EventAttestationCheckDone {

--- a/communication/u2fhid/hiddevice.go
+++ b/communication/u2fhid/hiddevice.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Shift Crypto AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package u2fhid
+
+import (
+	"io"
+	"runtime"
+
+	"github.com/karalabe/hid"
+)
+
+// HidDevice should be used to wrap a *hid.Device when used with `Communication`.
+//
+// On macOS only, we want to write only 64 bytes at a time. There was a bug in the BitBox firmware
+// (fixed in v9.23.1, see https://github.com/BitBoxSwiss/bitbox02-firmware/pull/1526) - when signing
+// a transaction, during the second inputs pass, 128 bytes are written to the hid device in one
+// shot, which results in a IOKit Timeout error. Writing only 64 bytes at a time (the HID report
+// size) fixes that. Otherwise we feed as many bytes as possible, which is important especially on
+// iOS, where we want to send as much as possible over Bluetooth instead of many little chunks.
+// /
+// From BitBox02 v9.23.1 onwards, this fix is not required, but we also saw some cases of firmware
+// upgrades failing on macOS, and we suspect the same bug in the bootloader <v1.1.2 might be causing
+// it, and writing 64 bytes at a time might fix it.
+type HidDevice struct {
+	io.ReadWriteCloser
+}
+
+// NewHidDevice wraps a hid device to write only 64 bytes at a time on macOS.
+func NewHidDevice(device hid.Device) *HidDevice {
+	return &HidDevice{ReadWriteCloser: device}
+}
+
+func (d *HidDevice) Write(data []byte) (int, error) {
+	if runtime.GOOS == "darwin" && len(data) > 64 {
+		data = data[:64]
+	}
+	return d.ReadWriteCloser.Write(data)
+}


### PR DESCRIPTION
See docstring in commit.