### PR TITLE
communication: move hiddevice to separate package

### DIFF
--- a/cmd/bluetooth_upgrade/main.go
+++ b/cmd/bluetooth_upgrade/main.go
@@ -24,6 +24,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware"
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/mocks"
 	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid"
+	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid/hiddevice"
 	"github.com/karalabe/hid"
 )
 
@@ -80,7 +81,7 @@ func main() {
 	hidDevice, err := deviceInfo.Open()
 	errpanic(err)
 
-	comm := u2fhid.NewCommunication(u2fhid.NewHidDevice(hidDevice), bitboxCMD)
+	comm := u2fhid.NewCommunication(hiddevice.New(hidDevice), bitboxCMD)
 	device := firmware.NewDevice(nil, nil, &mocks.Config{}, comm, &mocks.Logger{})
 	errpanic(device.Init())
 	device.ChannelHashVerify(true)

--- a/cmd/bootloader/main.go
+++ b/cmd/bootloader/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/bootloader"
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/common"
 	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid"
+	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid/hiddevice"
 	"github.com/BitBoxSwiss/bitbox02-api-go/util/errp"
 	"github.com/BitBoxSwiss/bitbox02-api-go/util/semver"
 	"github.com/karalabe/hid"
@@ -83,7 +84,7 @@ func main() {
 	hidDevice, err := deviceInfo.Open()
 	errpanic(err)
 	const bitbox02BootloaderCMD = 0x80 + 0x40 + 0x03
-	comm := u2fhid.NewCommunication(u2fhid.NewHidDevice(hidDevice), bitbox02BootloaderCMD)
+	comm := u2fhid.NewCommunication(hiddevice.New(hidDevice), bitbox02BootloaderCMD)
 	version, err := parseVersion(deviceInfo.Serial)
 	errpanic(err)
 	product, err := common.ProductFromDeviceProductString(deviceInfo.Product)

--- a/cmd/miniscript/main.go
+++ b/cmd/miniscript/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages"
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/mocks"
 	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid"
+	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid/hiddevice"
 	"github.com/benma/miniscript-go"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
@@ -203,7 +204,7 @@ func main() {
 	hidDevice, err := deviceInfo.Open()
 	errpanic(err)
 
-	comm := u2fhid.NewCommunication(u2fhid.NewHidDevice(hidDevice), bitboxCMD)
+	comm := u2fhid.NewCommunication(hiddevice.New(hidDevice), bitboxCMD)
 	device := firmware.NewDevice(nil, nil, &mocks.Config{}, comm, &mocks.Logger{})
 	errpanic(device.Init())
 	device.ChannelHashVerify(true)

--- a/cmd/paymentrequest/main.go
+++ b/cmd/paymentrequest/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages"
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/mocks"
 	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid"
+	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid/hiddevice"
 	"github.com/btcsuite/btcd/btcec/v2"
 	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
 	"github.com/btcsuite/btcd/wire"
@@ -128,7 +129,7 @@ func main() {
 	hidDevice, err := deviceInfo.Open()
 	errpanic(err)
 
-	comm := u2fhid.NewCommunication(u2fhid.NewHidDevice(hidDevice), bitboxCMD)
+	comm := u2fhid.NewCommunication(hiddevice.New(hidDevice), bitboxCMD)
 	device := firmware.NewDevice(nil, nil, &mocks.Config{}, comm, &mocks.Logger{})
 	errpanic(device.Init())
 	device.ChannelHashVerify(true)

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/messages"
 	"github.com/BitBoxSwiss/bitbox02-api-go/api/firmware/mocks"
 	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid"
+	"github.com/BitBoxSwiss/bitbox02-api-go/communication/u2fhid/hiddevice"
 	"github.com/karalabe/hid"
 )
 
@@ -194,7 +195,7 @@ func main() {
 	hidDevice, err := deviceInfo.Open()
 	errpanic(err)
 	const bitboxCMD = 0x80 + 0x40 + 0x01
-	comm := u2fhid.NewCommunication(u2fhid.NewHidDevice(hidDevice), bitboxCMD)
+	comm := u2fhid.NewCommunication(hiddevice.New(hidDevice), bitboxCMD)
 	device := firmware.NewDevice(nil, nil, &mocks.Config{}, comm, &mocks.Logger{})
 	device.SetOnEvent(func(ev firmware.Event, meta interface{}) {
 		if ev == firmware.EventAttestationCheckDone {

--- a/communication/u2fhid/hiddevice/hiddevice.go
+++ b/communication/u2fhid/hiddevice/hiddevice.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package u2fhid
+package hiddevice
 
 import (
 	"io"
@@ -37,8 +37,8 @@ type HidDevice struct {
 	io.ReadWriteCloser
 }
 
-// NewHidDevice wraps a hid device to write only 64 bytes at a time on macOS.
-func NewHidDevice(device hid.Device) *HidDevice {
+// New wraps a hid device to write only 64 bytes at a time on macOS.
+func New(device hid.Device) *HidDevice {
 	return &HidDevice{ReadWriteCloser: device}
 }
 


### PR DESCRIPTION
So the u2fhid package does not depend on karalabe/hid, which is optional and only useful on Desktop, not mobile. `gomobile` can fail because of this dep.